### PR TITLE
refactor: proposal of different named export syntax

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
 import main from './main'
-export default main
-export * from './VTable'
-export * from './VTh'
-export * from './VTr'
-export * from './VTPagination'
-export * from './types'
+import VTable from './VTable'
+import VTh from './VTh'
+import VTr from './VTr'
+import VTPagination from './VTPagination'
 
+export * from './types'
+export { VTable, VTh, VTr, VTPagination }
+
+export default main


### PR DESCRIPTION
Just an idea, I'm not sure if it's any different, but since VTable, VTh, VTr, VTPagination all have _default_ exports, I believe that this way of re-exporting those components as named exports is easier to reason about.