### PR TITLE
Fix VTPagination calculation of pages to show

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuejs-smart-table",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "files": [
     "dist"
   ],

--- a/src/VTPagination.ts
+++ b/src/VTPagination.ts
@@ -56,8 +56,16 @@ export default defineComponent({
       const totalTiers = Math.ceil(props.totalPages / props.maxPageLinks)
       const activeTier = Math.ceil((props.currentPage || 1) / props.maxPageLinks)
 
-      const start = ((activeTier - 1) * props.maxPageLinks) + 1
-      const end = start + props.maxPageLinks
+      let start = ((activeTier - 1) * props.maxPageLinks) + 1
+      const end = Math.min(start + props.maxPageLinks - 1, props.totalPages)
+
+      const totalEntries = end - start + 1
+      const missingAmount = props.maxPageLinks - totalEntries
+
+      const isLastTier = activeTier === totalTiers && activeTier > 1
+      if (isLastTier && missingAmount > 0) {
+        start = start - missingAmount
+      }
 
       if (activeTier > 1) {
         displayPages.push({
@@ -66,7 +74,7 @@ export default defineComponent({
         })
       }
 
-      for (let i = start; i < end; i++) {
+      for (let i = start; i <= end; i++) {
         if (i > props.totalPages) {
           break
         }
@@ -80,7 +88,7 @@ export default defineComponent({
       if (activeTier < totalTiers) {
         displayPages.push({
           title: '...',
-          value: end
+          value: end + 1
         })
       }
 


### PR DESCRIPTION
When calculating the links to show if we where in the last tier sometimes we only showed a couple of links.
With this change if we are in the last tier and we are missing some links we will back fill it.