### PR TITLE
Add a foot slot

### DIFF
--- a/src/VTable.ts
+++ b/src/VTable.ts
@@ -114,7 +114,15 @@ export default defineComponent({
         selectedRows: this.tableState.selectedRows,
         selectRow: this.selectRow,
         deselectRow: this.deselectRow,
-      }) : undefined)
+      }) : undefined),
+      h('tfoot', this.slots.foot ? this.slots.foot({
+        rows: this.tableState.rows,
+        selectedRows: this.tableState.selectedRows,
+        toggleAllRows: this.toggleAllRows,
+        selectAll: this.selectAll,
+        deselectAll: this.deselectAll,
+        allRowsSelected: this.allRowsSelected,
+      }) : undefined),
     ])
   }
 })


### PR DESCRIPTION
The goal of this commit is to add a <tfoot> to the table. This is basically a copy of the head slot but aimed at the footer of the table